### PR TITLE
Add a test and switch to package-imports

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,19 @@
+name: Run tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install Poetry
+      uses: snok/install-poetry@v1.1.1
+    - name: Install dependencies
+      run: poetry install
+    - name: Test with pytest
+      run: poetry run pytest

--- a/data_generator/configurations/constants.py
+++ b/data_generator/configurations/constants.py
@@ -1,4 +1,4 @@
-from configurations.units import unit_year, unit_kpc
+from data_generator.configurations.units import unit_year, unit_kpc
 from enum import Enum
 
 

--- a/data_generator/configurations/initial_galaxy_params.py
+++ b/data_generator/configurations/initial_galaxy_params.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
-import configurations.units as unt
-from configurations.constants import RADIATIVE_EFFICIENCY_ETA, FADE
+import data_generator.configurations.units as unt
+from data_generator.configurations.constants import RADIATIVE_EFFICIENCY_ETA, FADE
 
 @dataclass
 class InitialGalaxyParameters:
@@ -44,42 +44,9 @@ class InitialGalaxyParameters:
     # Parametras iš šviesio funkcijų
     duration_coef_exp_law: float = np.log(0.01) * drop_timescale
 
-    # Random number generator that contributes to smbh and bulge mass calculations
-    rng: np.random.RandomState = None
-
     @property
     def virial_radius(self):
         return (626 * (((self.virial_mass / (10 ** 13)) * unt.unit_sunmass) ** (1 / 3))) / unt.unit_kpc
-
-    @property
-    def smbh_mass(self):
-        # Calculate SMBH mass from total galaxy mass (including dark matter)
-        # Bandara et al. 2009, doi: 10.1088/0004-637X/704/2/1135 (equation 8)
-        free_coef = 8.18
-        if self.rng:
-            # We randomize the value of the first free coefficient to provide
-            # a realistic spread of smbh masses. Note that the bounds here
-            # are somewhat smaller than in the original equation and are
-            # sampled uniformly.
-            free_coef += self.rng.uniform(-0.4, 0.4)
-        log_smbh_mass = free_coef + (1.55 * (np.log10(self.virial_mass * unt.unit_sunmass) - 13.0))
-        smbh_mass = 10 ** log_smbh_mass
-        return smbh_mass / unt.unit_sunmass
-
-    @property
-    def bulge_mass(self):
-        # Calculate bulge mass from SMBH mass
-        # McConnell & Ma 2013, doi: 10.1088/0004-637X/764/2/184 (see abstract)
-        intercept_alpha = 8.46
-        if self.rng:
-            # We randomize the value of the first free coefficient to provide
-            # a realistic spread of bulge masses. Note that the bounds here
-            # were derived by visually inspecting the results.
-            intercept_alpha += self.rng.uniform(0.6, -0.6)
-        slope_beta = 1.05
-        log_bulge_mass = (np.log10(self.smbh_mass * unt.unit_sunmass) - intercept_alpha) / slope_beta
-        return (10 ** log_bulge_mass) * 1e11
-
     @property
     def bulge_to_total_mass_fraction(self):
         # Fraction of bulge vs whole galaxy mass
@@ -104,6 +71,40 @@ class InitialGalaxyParameters:
         raise AttributeError(
             "Unknown fade type %s, can't calculate quasar dt", self.fade
         )
+
+    def generate_stochastic_parameters(self, rng):
+        self.smbh_mass = self._smbh_mass(rng)
+        self.bulge_mass = self._bulge_mass(rng)
+        
+    def __post_init__(self):
+        self.generate_stochastic_parameters(None)
+
+    def _smbh_mass(self, rng=None):
+        # Calculate SMBH mass from total galaxy mass (including dark matter)
+        # Bandara et al. 2009, doi: 10.1088/0004-637X/704/2/1135 (equation 8)
+        free_coef = 8.18
+        if rng:
+            # We randomize the value of the first free coefficient to provide
+            # a realistic spread of smbh masses. Note that the bounds here
+            # are somewhat smaller than in the original equation and are
+            # sampled uniformly.
+            free_coef += rng.uniform(-0.4, 0.4)
+        log_smbh_mass = free_coef + (1.55 * (np.log10(self.virial_mass * unt.unit_sunmass) - 13.0))
+        smbh_mass = 10 ** log_smbh_mass
+        return smbh_mass / unt.unit_sunmass
+
+    def _bulge_mass(self, rng=None):
+        # Calculate bulge mass from SMBH mass
+        # McConnell & Ma 2013, doi: 10.1088/0004-637X/764/2/184 (see abstract)
+        intercept_alpha = 8.46
+        if rng:
+            # We randomize the value of the first free coefficient to provide
+            # a realistic spread of bulge masses. Note that the bounds here
+            # were derived by visually inspecting the results.
+            intercept_alpha += rng.uniform(0.6, -0.6)
+        slope_beta = 1.05
+        log_bulge_mass = (np.log10(self.smbh_mass * unt.unit_sunmass) - intercept_alpha) / slope_beta
+        return (10 ** log_bulge_mass) * 1e11
 
 
 dot_radius = 0

--- a/data_generator/configurations/switches.py
+++ b/data_generator/configurations/switches.py
@@ -1,4 +1,4 @@
-import configurations.constants as const
+import data_generator.configurations.constants as const
 
 repeating_equation = True
 smbh_grows = True

--- a/data_generator/configurations/units.py
+++ b/data_generator/configurations/units.py
@@ -1,6 +1,6 @@
 import math
 
-from configurations.physics_constants import GRAVITATIONAL
+from data_generator.configurations.physics_constants import GRAVITATIONAL
 
 unit_length = 3.086e21
 unit_mass = 5e9 * 1.989e33

--- a/data_generator/data_models/arrays_modifier.py
+++ b/data_generator/data_models/arrays_modifier.py
@@ -1,6 +1,6 @@
 import numpy as np
-import configurations.constants as const
-import configurations.initial_galaxy_params as params
+import data_generator.configurations.constants as const
+import data_generator.configurations.initial_galaxy_params as params
 
 
 def init_zero_arrays(arrays_count):

--- a/data_generator/main.py
+++ b/data_generator/main.py
@@ -5,15 +5,15 @@ import time
 import matplotlib.pyplot as plt
 import pandas as pd
 
-import configurations.initial_galaxy_params as init
-import configurations.switches as swch
-import configurations.units as unt
-from configurations.path_version_settings import params_path, values_version_folder, version, \
+import data_generator.configurations.initial_galaxy_params as init
+import data_generator.configurations.switches as swch
+import data_generator.configurations.units as unt
+from data_generator.configurations.path_version_settings import params_path, values_version_folder, version, \
     predictions_file
-from data_models.arrays_modifier import *
-from mathematical_calculations.DrivingForceIntegrator import DrivingForceIntegrator
-from mathematical_calculations.FadeTypeSwitcher import FadeTypeSwitcher
-from mathematical_calculations.mass_calculation import mass_calculation
+from data_generator.data_models.arrays_modifier import *
+from data_generator.mathematical_calculations.DrivingForceIntegrator import DrivingForceIntegrator
+from data_generator.mathematical_calculations.FadeTypeSwitcher import FadeTypeSwitcher
+from data_generator.mathematical_calculations.mass_calculation import mass_calculation
 
 all_params_columns = ['radius', 'dot_radius', 'derived_dot_mass', 'mass_out', 'luminosity_AGN', 'smbh_mass', \
                               'duty_cycle', 't_initial_smbh_mass', 'bulge_mass', 'bulge_gas', 'galaxy_mass', \
@@ -317,8 +317,10 @@ if __name__ == '__main__':
     smbh_m = []
     bulge_mas = []
     
+    initial_galaxy_parameters = init.InitialGalaxyParameters()
+
     rng = np.random.RandomState(0)
-    initial_galaxy_parameters = init.InitialGalaxyParameters(rng=rng)
+    initial_galaxy_parameters.generate_stochastic_parameters(rng)
 
     (db_file_header, df_index, virial_mass, smbh_m, bulge_mas, failed_outflows_mode_header) = run_outflow_simulation(
         initial_galaxy_parameters,

--- a/data_generator/mathematical_calculations/DrivingForceIntegrator.py
+++ b/data_generator/mathematical_calculations/DrivingForceIntegrator.py
@@ -1,8 +1,8 @@
 import math
 
-from configurations.physics_constants import LIGHT_SPEED
-from configurations.constants import DRIVING_FORCE, GAMMA
-from configurations.units import unit_length, unit_mass
+from data_generator.configurations.physics_constants import LIGHT_SPEED
+from data_generator.configurations.constants import DRIVING_FORCE, GAMMA
+from data_generator.configurations.units import unit_length, unit_mass
 
 
 class DrivingForceIntegrator:

--- a/data_generator/mathematical_calculations/FadeTypeSwitcher.py
+++ b/data_generator/mathematical_calculations/FadeTypeSwitcher.py
@@ -1,6 +1,6 @@
 import math
 
-import configurations.initial_galaxy_params as init
+import data_generator.configurations.initial_galaxy_params as init
 
 
 class FadeTypeSwitcher:

--- a/data_generator/mathematical_calculations/mass_calculation.py
+++ b/data_generator/mathematical_calculations/mass_calculation.py
@@ -1,7 +1,7 @@
 import math
-from configurations.units import unit_sunmass
-from mathematical_calculations.IsothermalProfile import IsothermalProfile
-from mathematical_calculations.NFWProfile import NFW
+from data_generator.configurations.units import unit_sunmass
+from data_generator.mathematical_calculations.IsothermalProfile import IsothermalProfile
+from data_generator.mathematical_calculations.NFWProfile import NFW
 
 
 def mass_calculation(radius, dot_radius, dotdot_radius, total_mass, virial_radius,

--- a/plotting_program/filtering_functions.py
+++ b/plotting_program/filtering_functions.py
@@ -12,9 +12,9 @@ from plotting_program.turning_plots_on_off import *
 warnings.filterwarnings('error')
 
 import numpy as np
-import configurations.constants as const
-from configurations.path_version_settings import params_path, values_version_folder
-from configurations.units import unit_sunmass
+import data_generator.configurations.constants as const
+from data_generator.configurations.path_version_settings import params_path, values_version_folder
+from data_generator.configurations.units import unit_sunmass
 from plotting_program.plots.generic_time_relation_plot import generic_time_relation_plot
 from plotting_program.plots.generic_radius_relation import generic_radius_relation_plot
 

--- a/plotting_program/plots/generic_lum_relation.py
+++ b/plotting_program/plots/generic_lum_relation.py
@@ -1,4 +1,4 @@
-from configurations.units import unit_sunmass
+from data_generator.configurations.units import unit_sunmass
 from plotting_program.plots.PlotSetup import PlotSetup
 import matplotlib.pyplot as plt
 import numpy as np

--- a/plotting_program/plots/plots_settings.py
+++ b/plotting_program/plots/plots_settings.py
@@ -1,6 +1,6 @@
 import os
 # from model_program.input_parameters.initial_values import version
-from configurations.path_version_settings import values_version_folder, version
+from data_generator.configurations.path_version_settings import values_version_folder, version
 
 graphs_path = "./graphs/"
 plots_version_folder = 'v' + str(version) + '.10_11/'

--- a/plotting_program/plots/smbh_relations.py
+++ b/plotting_program/plots/smbh_relations.py
@@ -1,8 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-from configurations.path_version_settings import version
-from configurations.physical_values import intercept_alpha, slope_beta, bulge_normalization_mass
+from data_generator.configurations.path_version_settings import version
+from data_generator.configurations.physical_values import intercept_alpha, slope_beta, bulge_normalization_mass
 from plotting_program.plots.PlotSetup import PlotSetup
 
 

--- a/plotting_program/plots_main.py
+++ b/plotting_program/plots_main.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from configurations.path_version_settings import params_path, values_version_folder
+from data_generator.configurations.path_version_settings import params_path, values_version_folder
 from plotting_program.plots.generic_time_relation_plot import generic_time_relation_plot
 from plotting_program.plots.generic_radius_relation import generic_radius_relation_plot
 

--- a/plotting_program/plots_main2.py
+++ b/plotting_program/plots_main2.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import matplotlib.pyplot as plt
 
-from configurations.physical_values import intercept_alpha, slope_beta, bulge_normalization_mass
+from data_generator.configurations.physical_values import intercept_alpha, slope_beta, bulge_normalization_mass
 from plotting_program.plots.PlotSetup import PlotSetup
 import numpy as np
-import configurations.constants as const
-from configurations.path_version_settings import params_path, values_version_folder, predictions_file, \
+import data_generator.configurations.constants as const
+from data_generator.configurations.path_version_settings import params_path, values_version_folder, predictions_file, \
     version
 from plotting_program.plots import smbh_relations
 from plotting_program.filtering_functions import \

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,29 @@ wrapt = ">=1.11,<2.0"
 
 [[package]]
 category = "dev"
+description = "Atomic file writes."
+marker = "sys_platform == \"win32\""
+name = "atomicwrites"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.4.0"
+
+[[package]]
+category = "dev"
+description = "Classes Without Boilerplate"
+name = "attrs"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.3.0"
+
+[package.extras]
+dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
+tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+
+[[package]]
+category = "dev"
 description = "The uncompromising code formatter."
 name = "black"
 optional = false
@@ -103,6 +126,14 @@ flake8 = "*"
 
 [[package]]
 category = "dev"
+description = "iniconfig: brain-dead simple config-ini parsing"
+name = "iniconfig"
+optional = false
+python-versions = "*"
+version = "1.1.1"
+
+[[package]]
+category = "dev"
 description = "A Python utility / library to sort Python imports."
 name = "isort"
 optional = false
@@ -172,20 +203,31 @@ python-versions = ">=3.6"
 version = "1.19.4"
 
 [[package]]
+category = "dev"
+description = "Core utilities for Python packages"
+name = "packaging"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "20.8"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+
+[[package]]
 category = "main"
 description = "Powerful data structures for data analysis, time series, and statistics"
 name = "pandas"
 optional = false
-python-versions = ">=3.6.1"
-version = "1.1.4"
+python-versions = ">=3.7.1"
+version = "1.2.0"
 
 [package.dependencies]
-numpy = ">=1.15.4"
+numpy = ">=1.16.5"
 python-dateutil = ">=2.7.3"
-pytz = ">=2017.2"
+pytz = ">=2017.3"
 
 [package.extras]
-test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
+test = ["pytest (>=5.0.1)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 category = "dev"
@@ -213,6 +255,17 @@ name = "pillow"
 optional = false
 python-versions = ">=3.6"
 version = "8.0.1"
+
+[[package]]
+category = "dev"
+description = "plugin and hook calling mechanisms for python"
+name = "pluggy"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.13.1"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "dev"
@@ -246,6 +299,14 @@ with_frosted = ["frosted (>=1.4.1)"]
 with_mypy = ["mypy (>=0.600)"]
 with_pyroma = ["pyroma (>=2.4)"]
 with_vulture = ["vulture (>=1.5)"]
+
+[[package]]
+category = "dev"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+name = "py"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.10.0"
 
 [[package]]
 category = "dev"
@@ -349,6 +410,27 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "2.4.7"
 
 [[package]]
+category = "dev"
+description = "pytest: simple powerful testing with Python"
+name = "pytest"
+optional = false
+python-versions = ">=3.6"
+version = "6.2.1"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=19.2.0"
+colorama = "*"
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
@@ -365,7 +447,7 @@ description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2020.4"
+version = "2020.5"
 
 [[package]]
 category = "dev"
@@ -454,7 +536,7 @@ python-versions = "*"
 version = "1.12.1"
 
 [metadata]
-content-hash = "17c09afae80e997a264238504f3c3677931614ad1258de1fbaa313b8f179d248"
+content-hash = "fd9dc0d15afbe264aeaa4e2bafbcddab9508f05918e1bf4e8d38bdc0369a93ae"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -465,6 +547,14 @@ appdirs = [
 astroid = [
     {file = "astroid-2.4.1-py3-none-any.whl", hash = "sha256:d8506842a3faf734b81599c8b98dcc423de863adcc1999248480b18bd31a0f38"},
     {file = "astroid-2.4.1.tar.gz", hash = "sha256:4c17cea3e592c21b6e222f673868961bad77e1f985cb1694ed077475a89229c1"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -492,6 +582,10 @@ flake8 = [
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -625,31 +719,28 @@ numpy = [
     {file = "numpy-1.19.4-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08"},
     {file = "numpy-1.19.4.zip", hash = "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"},
 ]
+packaging = [
+    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
+    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
+]
 pandas = [
-    {file = "pandas-1.1.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e2b8557fe6d0a18db4d61c028c6af61bfed44ef90e419ed6fadbdc079eba141e"},
-    {file = "pandas-1.1.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3aa8e10768c730cc1b610aca688f588831fa70b65a26cb549fbb9f35049a05e0"},
-    {file = "pandas-1.1.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:185cf8c8f38b169dbf7001e1a88c511f653fbb9dfa3e048f5e19c38049e991dc"},
-    {file = "pandas-1.1.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0d9a38a59242a2f6298fff45d09768b78b6eb0c52af5919ea9e45965d7ba56d9"},
-    {file = "pandas-1.1.4-cp36-cp36m-win32.whl", hash = "sha256:8b4c2055ebd6e497e5ecc06efa5b8aa76f59d15233356eb10dad22a03b757805"},
-    {file = "pandas-1.1.4-cp36-cp36m-win_amd64.whl", hash = "sha256:5dac3aeaac5feb1016e94bde851eb2012d1733a222b8afa788202b836c97dad5"},
-    {file = "pandas-1.1.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6d2b5b58e7df46b2c010ec78d7fb9ab20abf1d306d0614d3432e7478993fbdb0"},
-    {file = "pandas-1.1.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c681e8fcc47a767bf868341d8f0d76923733cbdcabd6ec3a3560695c69f14a1e"},
-    {file = "pandas-1.1.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c5a3597880a7a29a31ebd39b73b2c824316ae63a05c3c8a5ce2aea3fc68afe35"},
-    {file = "pandas-1.1.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6613c7815ee0b20222178ad32ec144061cb07e6a746970c9160af1ebe3ad43b4"},
-    {file = "pandas-1.1.4-cp37-cp37m-win32.whl", hash = "sha256:43cea38cbcadb900829858884f49745eb1f42f92609d368cabcc674b03e90efc"},
-    {file = "pandas-1.1.4-cp37-cp37m-win_amd64.whl", hash = "sha256:5378f58172bd63d8c16dd5d008d7dcdd55bf803fcdbe7da2dcb65dbbf322f05b"},
-    {file = "pandas-1.1.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a7d2547b601ecc9a53fd41561de49a43d2231728ad65c7713d6b616cd02ddbed"},
-    {file = "pandas-1.1.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:41746d520f2b50409dffdba29a15c42caa7babae15616bcf80800d8cfcae3d3e"},
-    {file = "pandas-1.1.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a15653480e5b92ee376f8458197a58cca89a6e95d12cccb4c2d933df5cecc63f"},
-    {file = "pandas-1.1.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:5fdb2a61e477ce58d3f1fdf2470ee142d9f0dde4969032edaf0b8f1a9dafeaa2"},
-    {file = "pandas-1.1.4-cp38-cp38-win32.whl", hash = "sha256:8a5d7e57b9df2c0a9a202840b2881bb1f7a648eba12dd2d919ac07a33a36a97f"},
-    {file = "pandas-1.1.4-cp38-cp38-win_amd64.whl", hash = "sha256:54404abb1cd3f89d01f1fb5350607815326790efb4789be60508f458cdd5ccbf"},
-    {file = "pandas-1.1.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:112c5ba0f9ea0f60b2cc38c25f87ca1d5ca10f71efbee8e0f1bee9cf584ed5d5"},
-    {file = "pandas-1.1.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:cf135a08f306ebbcfea6da8bf775217613917be23e5074c69215b91e180caab4"},
-    {file = "pandas-1.1.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b1f8111635700de7ac350b639e7e452b06fc541a328cf6193cf8fc638804bab8"},
-    {file = "pandas-1.1.4-cp39-cp39-win32.whl", hash = "sha256:09e0503758ad61afe81c9069505f8cb8c1e36ea8cc1e6826a95823ef5b327daf"},
-    {file = "pandas-1.1.4-cp39-cp39-win_amd64.whl", hash = "sha256:0a11a6290ef3667575cbd4785a1b62d658c25a2fd70a5adedba32e156a8f1773"},
-    {file = "pandas-1.1.4.tar.gz", hash = "sha256:a979d0404b135c63954dea79e6246c45dd45371a88631cdbb4877d844e6de3b6"},
+    {file = "pandas-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cba93d4fd3b0a42858b2b599495aff793fb5d94587979f45a14177d1217ba446"},
+    {file = "pandas-1.2.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9e18631d996fe131de6cb31a8bdae18965cc8f39eb23fdfbbf42808ecc63dabf"},
+    {file = "pandas-1.2.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7b54c14130a3448d81eed1348f52429c23e27188d9db6e6d4afeae792bc49c11"},
+    {file = "pandas-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:6c1a57e4d0d6f9633a07817c44e6b36d81c265fe4c52d0c0505513a2d0f7953c"},
+    {file = "pandas-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:43482789c55cbabeed9482263cfc98a11e8fcae900cb63ef038948acb4a72570"},
+    {file = "pandas-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0be6102dd99910513e75ed6536284743ead810349c51bdeadd2a5b6649f30abb"},
+    {file = "pandas-1.2.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9c6692cea6d56da8650847172bdb148622f545e7782d17995822434c79d7a211"},
+    {file = "pandas-1.2.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:272675a98fa4954b9fc0933df775596fc942e50015d7e75d8f19548808a2bfdf"},
+    {file = "pandas-1.2.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:33318fa24b192b1a4684347ff76679a7267fd4e547da9f71556a5914f0dc10e7"},
+    {file = "pandas-1.2.0-cp38-cp38-win32.whl", hash = "sha256:3bc6d2be03cb75981d8cbeda09503cd9d6d699fc0dc28a65e197165ad527b7b8"},
+    {file = "pandas-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:7904ee438549b5223ce8dc008772458dd7c5cf0ccc64cf903e81202400702235"},
+    {file = "pandas-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f8b87d2f541cd9bc4ecfe85a561abac85c33fe4de4ce70cca36b2768af2611f5"},
+    {file = "pandas-1.2.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:91fd0b94e7b98528177a05e6f65efea79d7ef9dec15ee48c7c69fc39fdd87235"},
+    {file = "pandas-1.2.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:8f92b07cdbfa3704d85b4264e52c216cafe6c0059b0d07cdad8cb29e0b90f2b8"},
+    {file = "pandas-1.2.0-cp39-cp39-win32.whl", hash = "sha256:2d8b4f532db37418121831a461fd107d826c240b098f52e7a1b4ab3d5aaa4fb2"},
+    {file = "pandas-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:616478c1bd8fe1e600f521ae2da434e021c11e7a4e5da3451d02906143d3629a"},
+    {file = "pandas-1.2.0.tar.gz", hash = "sha256:e03386615b970b8b41da6a68afe717626741bb2431cec993640685614c0680e4"},
 ]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
@@ -689,8 +780,16 @@ pillow = [
     {file = "Pillow-8.0.1-pp37-pypy37_pp73-win32.whl", hash = "sha256:8de332053707c80963b589b22f8e0229f1be1f3ca862a932c1bcd48dafb18dd8"},
     {file = "Pillow-8.0.1.tar.gz", hash = "sha256:11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e"},
 ]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
 prospector = [
     {file = "prospector-1.3.1.tar.gz", hash = "sha256:700d7918d93d73035a2a58fb18c6be0b609a0481fc6e0908843fa856b89e52c6"},
+]
+py = [
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -726,13 +825,17 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
+pytest = [
+    {file = "pytest-6.2.1-py3-none-any.whl", hash = "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8"},
+    {file = "pytest-6.2.1.tar.gz", hash = "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 pytz = [
-    {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
-    {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
+    {file = "pytz-2020.5-py2.py3-none-any.whl", hash = "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"},
+    {file = "pytz-2020.5.tar.gz", hash = "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "galactic_outflows_data_generator"
+name = "data_generator"
 version = "0.1.0"
 description = ""
 authors = []
@@ -13,6 +13,7 @@ pandas = "^1.1.4"
 [tool.poetry.dev-dependencies]
 prospector = "^1.3.1"
 black = {version = "^20.8b1", allow-prereleases = true}
+pytest = "^6.2.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_initial_galaxy_params.py
+++ b/tests/test_initial_galaxy_params.py
@@ -1,0 +1,20 @@
+import pytest
+import numpy as np
+
+import data_generator.configurations.initial_galaxy_params as init
+
+
+@pytest.mark.parametrize(
+    "rng, expected_bulge_mass",
+    [
+        (None, 19126721261),
+        (np.random.RandomState(0), 36708148026),
+        (np.random.RandomState(42), 50252088092),
+    ],
+)
+def test_bulge_mass(rng, expected_bulge_mass):
+    initial_galaxy_parameters = init.InitialGalaxyParameters()
+    if rng:
+        initial_galaxy_parameters.generate_stochastic_parameters(rng)
+
+    assert initial_galaxy_parameters.bulge_mass == pytest.approx(expected_bulge_mass)


### PR DESCRIPTION
Added a simple test (see bottom of change list) and a github job to run it (example: https://github.com/messier20/galactic_outflows_data_generator/actions/runs/453267138). This should run on every commit. Github gives you up to 2000 free minutes for running jobs (per project), so why not use it.  Two more changes to the code:

1. Reverted the imports to the way you used to do it - should work fine if we're treating `data_generator` like a package, which I wasn't sure of before.
2. Put more space between the random number generator and galaxy parameters (there's a separate function that you have to call explicitly to get randomized bulge and smbh mass). I think this makes the randomization behavior clearer (and also easier to test).

The test here barely does anything useful, but we can add more substantial tests later. I'd rather have at least *something* running now than nothing.